### PR TITLE
Create list of common fields for #23

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,6 +57,14 @@
                     </ul>
                   </li>
                   <li class="dropdown">
+                    <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" href="#">Results
+                      <b class="caret"></b>
+                    </a>
+                    <ul class="dropdown-menu">
+                      <li><a href="/common-fields/">Common Fields</a></li>
+                    </ul>
+                  </li>
+                  <li class="dropdown">
                     <a data-target="#" data-toggle="dropdown" class="dropdown-toggle" href="#">Metadata
                       <b class="caret"></b>
                     </a>

--- a/common-fields.md
+++ b/common-fields.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: Common Fields
+permalink: /common-fields/
+---
+
+# Common Fields in results files.
+
+updated_at
+
+id
+
+start_date
+
+end_date
+
+election_type
+
+result_type
+
+special
+
+office
+
+district
+
+name_raw
+
+last_name
+
+first_name
+
+suffix
+middle_name
+
+party
+
+jurisdiction
+
+divission
+
+votes
+
+votes_type
+
+total_votes
+
+winner
+
+write_in
+
+year


### PR DESCRIPTION
Changes:

- adds list of fields common across the following files:
	```
	20000822__wy__primary__precinct__raw.csv
	20051108__va__general__precinct__raw.csv
	20110301__fl__general__county__raw.csv
	20121106__nc__general__precinct__raw.csv
	20140107__ia__general__county__raw.csv
	20140513__wv__primary__precinct__raw.csv
	20140603__ms__primary__precinct__raw.csv
	20140610__nv__primary__county__raw.csv
	20140624__md__primary__county__raw.csv
	20140624__ms__primary_runoff__precinct__raw.csv
	20140805__mo__general__county__raw.csv
	20141104__az__general__county__raw.csv
	20141104__md__general__county__raw.csv
	20141104__mt__general__county__raw.csv
	20141104__or__general__precinct__raw.csv
	20141104__pa__general__precinct__raw.csv
	20150221__la__primary__parish__raw.csv
	20151121__la__general__parish__raw.csv
	20160126__tx__general_runoff__county__raw.csv
	20161108__fl__general__county__raw.csv
	```
- creates new top-level menu item "Results" and drop-down item "Common Fields"

To do:
- [ ] definitions
- [ ] check that this builds correctly; I wasn't able to get jekyll to render this [by following Github's instructions](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/)