### PR TITLE
Import docs on Results Data Spec v2

### DIFF
--- a/common-fields.md
+++ b/common-fields.md
@@ -8,38 +8,38 @@ permalink: /common-fields/
 
 ### Introduction
 
-Each election date represents a directory containing CSV and JSON files covering elections to specific offices. For example, Maryland's Nov. 6, 2012 general election results would be stored in a /md/2012-11-06/ directory, and the filenames would represent offices such as "president", "us-senate" and "us-house". Each office file would contain one record for each candidate listed in the results. The result records consist of at least these fields.
+Each election year represents a directory containing data files covering elections occurring in that year. Each election held during that year contains one record for each candidate listed in the results. The result records consist of at least these fields:
 
-[Example JSON results file](https://gist.github.com/dwillis/5666920)
-
-[Example CSV results file](https://gist.github.com/dwillis/5666870)
+[Example CSV results file](https://github.com/openelections/openelections-results-fl/blob/master/raw/20000905__fl__primary__county__raw.csv)
 
 ### Fields
 
 | Field | Type | Description |
 |---|---|---|
-| election_id | string | OpenElections-created slug for election |
-| office_name | string | name of office sought |
-| office_district | string | district number or designation |
-| division | string | political jurisdiction using [Open Civic Data Division Identifiers](https://github.com/opencivicdata/ocd-division-ids) - acts as reporting level |
-| given_name | string | parsed given name of the candidate|
-| additional_name | string | parsed middle name or initial of the candidate|
-| family_name | string | parsed family name of the candidate |
+| updated_at | | |
+| id | string | OpenElections-created slug for election |
+| start_date | string | |
+| end_date | string | |
+| election_type | string | |
+| result_type | string | |
+| special | string | |
+| office | string | name of office sought |
+| district | string | district number or designation |
+| name_raw | string | "raw" full name of the candidate from the results, if present |
+| last_name | string | parsed family name of the candidate |
+| first_name | string | parsed given name of the candidate|
 | suffix | string | parsed suffix of the candidate |
-| name | string | "raw" full name of the candidate from the results, if present |
-| other_names | array | array of additional names with `note` label |
+| middle_name | string | parsed middle name or initial of the candidate|
 | party | string | "raw" party name or abbreviation from the results (`None` for non-partisan) |
-| winner | boolean | true for the winning candidate(s) within this division; all other candidates are marked as false |
+| jurisdiction | string | |
+| division | string | political jurisdiction using [Open Civic Data Division Identifiers](https://github.com/opencivicdata/ocd-division-ids) - acts as reporting level |
 | votes | integer | number of votes received by the candidate within this division|
-| pct | decimal | percentage of votes received by the candidate within this division|
+| vote_type | | |
+| total_votes | | |
+| winner | boolean | true for the winning candidate(s) within this division; all other candidates are marked as false |
 | write_in | boolean | true if the candidate is a write-in candidate |
+| year | integer | |
 
 ### Questions
 
 Join us on [the Google Group](https://groups.google.com/forum/?fromgroups=#!forum/openelections) to discuss these specs, or you can [file an issue](https://github.com/openelections/docs/issues/new) on this Github repository, too.
-
-1. Should the results data have a `results_type` attribute in the event that both Unofficial and Certified data is available? Or does that information belong in the Elections data, perhaps in the `election_id`?
-2. For states like Maryland that have an Other Write-Ins value, should that go in `family_name` or just `name`?
-3. Should the results data have incumbency status?
-4. Should the office fields be collapsed into a single one, perhaps based on the OCD division IDs?
-5. How should the `other_names` array be represented in CSV?

--- a/common-fields.md
+++ b/common-fields.md
@@ -4,49 +4,42 @@ title: Common Fields
 permalink: /common-fields/
 ---
 
-# Common Fields in results files.
+# Common Fields in results files
 
-updated_at
+### Introduction
 
-id
+Each election date represents a directory containing CSV and JSON files covering elections to specific offices. For example, Maryland's Nov. 6, 2012 general election results would be stored in a /md/2012-11-06/ directory, and the filenames would represent offices such as "president", "us-senate" and "us-house". Each office file would contain one record for each candidate listed in the results. The result records consist of at least these fields.
 
-start_date
+[Example JSON results file](https://gist.github.com/dwillis/5666920)
 
-end_date
+[Example CSV results file](https://gist.github.com/dwillis/5666870)
 
-election_type
+### Fields
 
-result_type
+| Field | Type | Description |
+|---|---|---|
+| election_id | string | OpenElections-created slug for election |
+| office_name | string | name of office sought |
+| office_district | string | district number or designation |
+| division | string | political jurisdiction using [Open Civic Data Division Identifiers](https://github.com/opencivicdata/ocd-division-ids) - acts as reporting level |
+| given_name | string | parsed given name of the candidate|
+| additional_name | string | parsed middle name or initial of the candidate|
+| family_name | string | parsed family name of the candidate |
+| suffix | string | parsed suffix of the candidate |
+| name | string | "raw" full name of the candidate from the results, if present |
+| other_names | array | array of additional names with `note` label |
+| party | string | "raw" party name or abbreviation from the results (`None` for non-partisan) |
+| winner | boolean | true for the winning candidate(s) within this division; all other candidates are marked as false |
+| votes | integer | number of votes received by the candidate within this division|
+| pct | decimal | percentage of votes received by the candidate within this division|
+| write_in | boolean | true if the candidate is a write-in candidate |
 
-special
+### Questions
 
-office
+Join us on [the Google Group](https://groups.google.com/forum/?fromgroups=#!forum/openelections) to discuss these specs, or you can [file an issue](https://github.com/openelections/docs/issues/new) on this Github repository, too.
 
-district
-
-name_raw
-
-last_name
-
-first_name
-
-suffix
-middle_name
-
-party
-
-jurisdiction
-
-divission
-
-votes
-
-votes_type
-
-total_votes
-
-winner
-
-write_in
-
-year
+1. Should the results data have a `results_type` attribute in the event that both Unofficial and Certified data is available? Or does that information belong in the Elections data, perhaps in the `election_id`?
+2. For states like Maryland that have an Other Write-Ins value, should that go in `family_name` or just `name`?
+3. Should the results data have incumbency status?
+4. Should the office fields be collapsed into a single one, perhaps based on the OCD division IDs?
+5. How should the `other_names` array be represented in CSV?


### PR DESCRIPTION
## Changes

- imports format and some field descriptions from https://github.com/openelections/specs/wiki/Results-Data-Spec-Version-2
- keeps list of common fields generated in https://github.com/openelections/docs/pull/32
- adds preface text

## To do:

- [ ] fill in missing descriptions and types for fields
- [ ] check that preface paragraph is correct